### PR TITLE
[MEM-167] Rename Meeshkan to Mem

### DIFF
--- a/Formula/meeshkan.rb
+++ b/Formula/meeshkan.rb
@@ -1,4 +1,4 @@
-class Meeshkan < Formula
+class Mem < Formula
   include Language::Python::Virtualenv
 
   desc "Mock HTTP APIs"

--- a/Formula/meeshkan.rb
+++ b/Formula/meeshkan.rb
@@ -2,10 +2,10 @@ class Mem < Formula
   include Language::Python::Virtualenv
 
   desc "Mock HTTP APIs"
-  homepage "https://github.com/meeshkan/meeshkan"
-  url "https://github.com/meeshkan/meeshkan/archive/v0.2.21.tar.gz"
+  homepage "https://github.com/meeshkan/mem"
+  url "https://github.com/meeshkan/mem/archive/v0.2.21.tar.gz"
   sha256 "5ac3a1a10e98b6c8e95a6310a77a0b8b736d1e55998ab42cf21c068b044141cc"
-  head "https://github.com/meeshkan/meeshkan.git"
+  head "https://github.com/meeshkan/mem.git"
 
   depends_on "python@3.8"
   resource "aiohttp" do

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Homebrew tap for meeshkan
-A homebrew tap to install the [meeshkan](https://github.com/meeshkan/meeshkan) schema builder and mocking tool using [Homebrew](https://brew.sh/):
+# Homebrew tap for Mem
+A homebrew tap to install the [Mem](https://github.com/mem/mem) schema builder and mocking tool using [Homebrew](https://brew.sh/):
 
 ```sh
-brew tap meeshkan/tap
-brew install meeshkan
+brew tap mem/tap
+brew install mem
 ```
 
 # For developers
 
-Run `./generate-formula.sh` to update [Formula/meeshkan.rb](Formula/meeshkan.rb) with the latest version published to PyPi.
+Run `./generate-formula.sh` to update [Formula/mem.rb](Formula/mem.rb) with the latest version published to PyPi.
 
-Run `brew reinstall --build-from-source Formula/meeshkan.rb` to test installing the package locally before pushing.
+Run `brew reinstall --build-from-source Formula/mem.rb` to test installing the package locally before pushing.

--- a/generate-formula.sh
+++ b/generate-formula.sh
@@ -3,32 +3,32 @@
 set -e -u
 
 echo "Installing using pip..."
-pip install --upgrade homebrew-pypi-poet meeshkan
+pip install --upgrade homebrew-pypi-poet mem
 
-MEESHKAN_VERSION=`pip show meeshkan | grep Version: | cut -f 2 -d ' '`
-echo "meeshkan version: $MEESHKAN_VERSION"
-MEESHKAN_TARFILE=v$MEESHKAN_VERSION.tar.gz
-MEESHKAN_URL=https://github.com/meeshkan/meeshkan/archive/$MEESHKAN_TARFILE
-echo "Downloading $MEESHKAN_URL ..."
-curl -L -O $MEESHKAN_URL
-MEESHKAN_CHECKSUM=`sha256sum $MEESHKAN_TARFILE | cut -f 1 -d ' '`
+MEM_VERSION=`pip show mem | grep Version: | cut -f 2 -d ' '`
+echo "mem version: $MEM_VERSION"
+MEM_TARFILE=v$MEM_VERSION.tar.gz
+MEM_URL=https://github.com/meeshkan/mem/archive/$MEM_TARFILE
+echo "Downloading $MEM_URL ..."
+curl -L -O $MEM_URL
+MEM_CHECKSUM=`sha256sum $MEM_TARFILE | cut -f 1 -d ' '`
 
-OUTPUT=Formula/meeshkan.rb
+OUTPUT=Formula/mem.rb
 
 cat > $OUTPUT <<EOF
 class Mem < Formula
   include Language::Python::Virtualenv
 
   desc "Mock HTTP APIs"
-  homepage "https://github.com/meeshkan/meeshkan"
-  url "$MEESHKAN_URL"
-  sha256 "$MEESHKAN_CHECKSUM"
-  head "https://github.com/meeshkan/meeshkan.git"
+  homepage "https://github.com/meeshkan/mem"
+  url "$MEM_URL"
+  sha256 "$MEM_CHECKSUM"
+  head "https://github.com/meeshkan/mem.git"
 
   depends_on "python@3.8"
 EOF
 
-poet meeshkan >> $OUTPUT
+poet mem >> $OUTPUT
 
 cat >> $OUTPUT <<EOF
   def install

--- a/generate-formula.sh
+++ b/generate-formula.sh
@@ -16,7 +16,7 @@ MEESHKAN_CHECKSUM=`sha256sum $MEESHKAN_TARFILE | cut -f 1 -d ' '`
 OUTPUT=Formula/meeshkan.rb
 
 cat > $OUTPUT <<EOF
-class Meeshkan < Formula
+class Mem < Formula
   include Language::Python::Virtualenv
 
   desc "Mock HTTP APIs"


### PR DESCRIPTION
Blocked by https://github.com/meeshkan/meeshkan/pull/186

As decided in the new product discussions, we will be renaming this product to `Mem` in favor of our new product having the `Meeshkan` name.

For this PR, here are all of the steps I went through:

```bash
git grep -l 'Meeshkan' | xargs sed -i '' -e 's/Meeshkan/Mem/g'
git grep -l 'meeshkan' | xargs sed -i '' -e 's/meeshkan/mem/g'
```

Then I manually went through and fixed some of the changes that are supposed to stay Meeshkan (referencing the company or GitHub org).

Each commit corresponds to those commands. 

Once merged:
- [ ] Rename repo description